### PR TITLE
Fix parseInt radix usage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -573,7 +573,7 @@ export default function App ({ halfTime, initTime = 0, homeDir = false }) {
               const nextPeriod = parseInt(result) > parseInt(halfTimeEnd) ? 'st' : 'pt'
               if (fractionElem.textContent !== nextPeriod) {
                 const savedHomeDir = localStorage.getItem('homeDirEnd')
-                const homeDir = savedHomeDir ? Boolean(parseInt(savedHomeDir, 0)) : false
+                const homeDir = savedHomeDir ? Boolean(parseInt(savedHomeDir, 10)) : false
                 if (nextPeriod === 'pt') {
                   setHomeDirEnd(homeDir)
                   direction.textContent = homeDir ? '1°◀' : '1°▶'

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ import '@fontsource/roboto/700.css'
 const savedHalfTime = localStorage.getItem('halfTimeEnd')
 const savedInitTime = localStorage.getItem('initTimeEnd')
 const savedHomeDir = localStorage.getItem('homeDirEnd')
-const halfTime = savedHalfTime ? parseInt(savedHalfTime, 0) : null
-const initTime = savedInitTime ? parseInt(savedInitTime, 0) : null
-const homeDir = savedHomeDir ? Boolean(parseInt(savedHomeDir, 0)) : false
+const halfTime = savedHalfTime ? parseInt(savedHalfTime, 10) : null
+const initTime = savedInitTime ? parseInt(savedInitTime, 10) : null
+const homeDir = savedHomeDir ? Boolean(parseInt(savedHomeDir, 10)) : false
 const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(<App halfTime={halfTime} initTime={initTime} homeDir={homeDir}/>)


### PR DESCRIPTION
## Summary
- ensure parseInt is always called with base 10 in index.js and App.js

## Testing
- `yarn test` *(fails: couldn't find a test script)*
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68400acbf59c8329b6eb1e13f49d9815